### PR TITLE
[repl] better help display

### DIFF
--- a/src/city.c
+++ b/src/city.c
@@ -103,7 +103,7 @@ char* city_arr_to_csv(City_Array city_arr)
 }
 
 // fonction interne non documentée parce que j'ai la flemme
-void print_row_border(int code_max_len, int name_max_len, int lat_max_len, int lon_max_len, bool newline)
+static void print_row_border(int code_max_len, int name_max_len, int lat_max_len, int lon_max_len, bool newline)
 {
     printf("+");
     for (size_t i = 0; i <= code_max_len + name_max_len + lat_max_len + lon_max_len + 3; i++)

--- a/src/repl.c
+++ b/src/repl.c
@@ -3,24 +3,65 @@
 #include "utils.h"
 #include "sorting.h"
 
+static void print_row_border(int n)
+{
+    printf("+");
+    for (int i = 0; i <= n; i++)
+    {
+        printf("-");
+    }
+    printf("+\n");
+}
+
+int my_strlen(const char* str)
+{
+    int i = 0;
+    while (str[i] != '\0')
+    {
+        i++;
+    }
+    return i;
+}
+
 void repl_help()
 {
-    printf("\e[4;34mCommandes :\e[0m\n");
-    printf("+--------------------------------------------------------------+\n");
-    printf("| a - Ajoute une ville                                         |\n");
-    printf("| \e[1;31ms - Supprime une ville\e[0m                                       |\n");
-    printf("| \e[1;33mm - Modifie les données d'une ville\e[0m                          |\n");
-    printf("| l - Liste les villes                                         |\n");
-    printf("| o - Calcule la distance à vol d'oiseau entre 2 villes        |\n");
-    printf("| \e[1;32me - Exporte les données dans un fichier CSV\e[0m                  |\n");
-    printf("| r - Affiche la latitude et longitude d'une ville             |\n");
-    printf("| t - Trie les villes par rapport à leur distance au Pole Nord |\n");
-#ifdef DEBUG
-    printf("| d - Debug\e[0m                                                    |\n");
-#endif
-    printf("| \e[1;32mh - Affiche l'aide\e[0m                                           |\n");
-    printf("| \e[1;31mq - Quitte le programme\e[0m                                      |\n");
-    printf("+--------------------------------------------------------------+\n");
+
+    int padding = strlen("commande") - 1; // -1 parce que chaque commande fait 1 caractère de long
+    int max_len = 0;
+    for (size_t i = 0; i < NB_COMMANDS; i++)
+    {
+        if (desc_sizes[i] > max_len)
+            max_len = desc_sizes[i];
+    }
+    max_len += 5 + padding;
+
+    print_row_border(max_len);
+    printf("| \e[4;35mcommande\e[0m | \e[4;35mdescription\e[0m");
+    size_t it = max_len - 3 - (strlen("description") + strlen("commande"));
+    for (size_t i = 0; i < it; i++)
+    {
+        printf(" ");
+    }
+    printf("|\n");
+    print_row_border(max_len);
+
+    for (size_t i = 0; i < NB_COMMANDS; i++)
+    {
+        // padding vers la droite
+        printf("|");
+        for (size_t j = 0; j <= padding; j++)
+        {
+            printf(" ");
+        }
+        printf("\e[4;33m%s\e[0m", all_commands[i]);
+        printf(" | \e[0;34m%s\e[0m", commands_description[i]);
+        for (size_t j = 0; j < max_len - padding - 4 - desc_sizes[i]; j++)
+        {
+            printf(" ");
+        }
+        printf("|\n");
+    }
+    print_row_border(max_len);
 }
 
 bool repl_is_valid_command(const char *command)

--- a/src/repl.h
+++ b/src/repl.h
@@ -11,10 +11,54 @@
 #endif
 
 static const char* all_commands[NB_COMMANDS] = {
-    "a", "s", "m", "l", "h", "q", "r", "e", "o", "t",
+    "a",
+    "s",
+    "m",
+    "l",
+    "r",
+    "e",
+    "o",
+    "t",
 #ifdef DEBUG
     "d",
 #endif
+    "h",
+    "q",
+};
+
+static const char* commands_description[NB_COMMANDS] = {
+    "Ajoute une ville",
+    "Supprime une ville",
+    "Modifie les données d'une ville",
+    "Liste les villes",
+    "Calcule la distance à vol d'oiseau entre 2 villes",
+    "Exporte les données dans un fichier CSV",
+    "Affiche la latitude et longitude d'une ville",
+    "Trie les villes par rapport à leur distance au Pole Nord",
+#ifdef DEBUG
+    "Debug",
+#endif
+    "Affiche l'aide",
+    "Quitte le programme",
+};
+
+// table des tailles de chaque description de commande.
+// normalement strlen() fait le job, mais on des fois
+// elle renvoie la taille + 1.
+static const int desc_sizes[NB_COMMANDS] = {
+    16,
+    18,
+    31,
+    16,
+    49,
+    39,
+    44,
+    56,
+#ifdef DEBUG
+    5,
+#endif
+    14,
+    19,
 };
 
 // Affiche la liste des commandes displonibles au sein du REPL


### PR DESCRIPTION
using a lookup table with all the correct sizes of each command description to print the help correctly because sometimes `strlen()` returns the size of the string +1 for some reason.